### PR TITLE
fix(webpack): fix babelify

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,8 +49,9 @@ module.exports = {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        include: /src/,
         query: {
-          presets: [["es2015", {"loose": true}]]
+          presets: ["es2015"]
         }
       }
     ]


### PR DESCRIPTION
Loose mode is no longer needed. Only load src folder.